### PR TITLE
[WIP] Avoid create project with the "app" name

### DIFF
--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -53,6 +53,12 @@ async function command (context) {
     process.exit(exitCodes.PROJECT_NAME)
   }
 
+  // Guard against `ignite new app`
+  if (toLower(projectName) === 'app') {
+    print.error(`Hey... This is a protected word. Please name your project something other than '${projectName}'.`)
+    process.exit(exitCodes.PROJECT_NAME)
+  }
+  
   // verify the project name isn't kebab cased
   if (isKebabCase) {
     print.error(`Please use camel case for your project name. Ex: ${projectNameCamel}`)


### PR DESCRIPTION

## Please verify the following:
- [ ] Everything works on iOS/Android
- [ ] `npm test` **ava** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

## Describe your PR
To avoid the error below, blocks uses from 'app' as app name

```
vvv -----[ DEBUG ]----- vvv
{ Error: ENOTEMPTY: directory not empty, rename '/Users/me/tmp/app/app/App' -> '/Users/sidferreira/tmp/app/App'
    at Object.fs.renameSync (fs.js:774:18)
    at Object.moveSync [as sync] (/usr/local/lib/node_modules/ignite-cli/node_modules/fs-jetpack/lib/move.js:27:8)
    at Object.move (/usr/local/lib/node_modules/ignite-cli/node_modules/fs-jetpack/lib/jetpack.js:183:12)
    at filename (/usr/local/lib/node_modules/ignite-cli/src/commands/new.js:144:30)
    at forEach (/usr/local/lib/node_modules/ignite-cli/node_modules/ramda/src/forEach.js:43:5)
    at /usr/local/lib/node_modules/ignite-cli/node_modules/ramda/src/internal/_checkForMethod.js:22:10
    at f2 (/usr/local/lib/node_modules/ignite-cli/node_modules/ramda/src/internal/_curry2.js:25:16)
    at Command.command [as run] (/usr/local/lib/node_modules/ignite-cli/src/commands/new.js:143:5)
    at process._tickCallback (internal/process/next_tick.js:103:7)
  errno: -66,
  code: 'ENOTEMPTY',
  syscall: 'rename',
  path: '/Users/me/tmp/app/app/App',
  dest: '/Users/me/tmp/app/App' }
^^^ -----[ DEBUG ]----- ^^^
```

